### PR TITLE
Setting Tomcat URL to the latest version

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -46,7 +46,7 @@ class java-development-env {
   }
 
   
-  $tomcat_url = "http://apache.mirrors.pair.com/tomcat/tomcat-7/v7.0.42/bin/apache-tomcat-7.0.42.tar.gz"
+  $tomcat_url = "http://apache.mirrors.pair.com/tomcat/tomcat-7/v7.0.50/bin/apache-tomcat-7.0.50.tar.gz"
    
   Exec {
     path  => "${::path}",


### PR DESCRIPTION
The mirrors only contain one single version (the latest one) so the
previous URL 404'ed.

And a quick thanks for starting this project. It's a great starting place for a newbie to Vagrant & Puppet like myself & has helped me dive right in & prove to the dev office this is a great way to develop going forward.
