### PR TITLE
Add out of the box support for remote deploying/debugging to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Ensure you have the following tools installed:
   * use ```sudo supervisorctl start tomcat``` to start tomcat
 * Vagrant is setup to map port 8080 of the VM to port 4880 on your machine
 	*  http://localhost:4880/
+* JMX support is enabled on the server: Vagrant is setup to map port 1099 of the VM to port 1099 on your machine, allowing for monitoring and remote deployment.
+* Tomcat is started in debug mode: Vagrant is setup to map port 8000 of the VM to port 4800 on your machine, allowing for debugging from your IDE.
 
 ## Package as a box for customizing in your projects
 * After box is configured and provisioned, you can package and use this as your base box to speed up your subsequent reloads

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,11 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "precise32"
+  config.vm.network :private_network, ip: '192.168.33.10'
   config.vm.network :forwarded_port, guest: 8080, host: 4880
+  config.vm.network :forwarded_port, guest: 8000, host: 4800
+  config.vm.network :forwarded_port, guest: 1099, host: 1099
+  config.vm.synced_folder "/tmp/artifacts", "/tmp/artifacts", create: true
   config.vm.provision :puppet, :module_path => "manifests/modules" do |puppet|
     puppet.manifests_path = "manifests"
     puppet.manifest_file  = "default.pp"

--- a/manifests/Puppetfile
+++ b/manifests/Puppetfile
@@ -1,8 +1,6 @@
 forge "http://forge.puppetlabs.com"
 
-mod 'apt',
-   :git => 'https://github.com/puppetlabs/puppetlabs-apt.git',
-   :ref => 'feature/master/dans_refactor'
-
-mod 'stdlib',
-	:git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+mod 'puppetlabs/apt', '1.4.2'
+mod 'puppetlabs/stdlib', '3.2.1'
+mod 'maestrodev/maven', '1.1.11'
+mod 'maestrodev/wget', '1.4.1'


### PR DESCRIPTION
Minor changes, thought it might be useful to someone:
- Update tomcat download URL to latest
- Added network address and (opinionated) port forwarding to vagrant file
- Added synced folder to vagrant file for remotely deploying artifacts from IDE 
- Added missing/broken librarian dependencies
- Added tomcat admin credentials to maven settings
- Added necessary roles for remotely deploying
- Added `setenv.sh` script for starting tomcat with remote JMX and debug support
